### PR TITLE
update db ping call in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ MONGODB_URI=mongodb+srv://USERNAME:PASSWORD@clustername.subdomain.mongodb.net/?r
 2. You can test your credentials by using the code's API endpoint
 
 ```
-<siteroot>/api/ping/
+<siteroot>/api/test_mongodb/
 ```
 
 Find the site's root URL by going to the "Ports" tab and click on the globe icon of port 80


### PR DESCRIPTION
Hello. Apologies for the random PR, but this is very minor. Testing out this repo and there is a small error in the readme instructions.  The route to test the mongo db connection is api/test_mongodb as seen on line 39 of api.php